### PR TITLE
The childNodes method supprot

### DIFF
--- a/TFHppleElement.h
+++ b/TFHppleElement.h
@@ -47,6 +47,10 @@
 //   class = 'highlight'
 - (NSDictionary *) attributes;
 
+// Return sub elements
+// http://sh3ng.com
+- (NSArray *) childNodes;
+
 // Provides easy access to the content of a specific attribute, 
 // such as 'href' or 'class'.
 - (NSString *) objectForKey:(NSString *) theKey;

--- a/TFHppleElement.m
+++ b/TFHppleElement.m
@@ -34,6 +34,7 @@ NSString * const TFHppleNodeContentKey           = @"nodeContent";
 NSString * const TFHppleNodeNameKey              = @"nodeName";
 NSString * const TFHppleNodeAttributeArrayKey    = @"nodeAttributeArray";
 NSString * const TFHppleNodeAttributeNameKey     = @"attributeName";
+NSString * const TFHppleNodeChildArrayKey        = @"nodeChildArray";
 
 @implementation TFHppleElement
 
@@ -75,6 +76,18 @@ NSString * const TFHppleNodeAttributeNameKey     = @"attributeName";
                              forKey:[attributeDict objectForKey:TFHppleNodeAttributeNameKey]];
   }
   return translatedAttributes;
+}
+
+- (NSArray *) childNodes {
+    NSDictionary * dic = [node objectForKey:TFHppleNodeChildArrayKey];
+    
+    NSMutableArray * hppleElements = [NSMutableArray array];
+    for (id childNode in dic) {
+        TFHppleElement * e = [[TFHppleElement alloc] initWithNode:childNode];
+        [hppleElements addObject:e];
+        [e release];
+    }
+    return hppleElements;
 }
 
 - (NSString *) objectForKey:(NSString *) theKey


### PR DESCRIPTION
Use for nested structure, avoid parse again,
example:

NodeA has Node1..Node9

on normal, have to parse NodeA then use For or While parse each node.
use the method only parse one time, then get each child node.
