### PR TITLE
Add methods to TFHppleElement to simplify access child elements by className

### DIFF
--- a/TFHppleElement.h
+++ b/TFHppleElement.h
@@ -82,6 +82,16 @@
 // Returns nil if no matching child is found
 - (TFHppleElement *) firstChildWithTagName:(NSString *)tagName;
 
+// Returns the children whose class equals the given string
+// (comparison is performed with NSString's isEqualToString)
+// Returns an empty array if no matching child is found
+- (NSArray *) childrenWithClassName:(NSString *)className;
+
+// Returns the first child whose class requals the given string
+// (comparison is performed with NSString's isEqualToString)
+// Returns nil if no matching child is found
+- (TFHppleElement *) firstChildWithClassName:(NSString*)className;
+
 // Returns the first text node from this element's children
 // Returns nil if there is no text node among the children
 - (TFHppleElement *) firstTextChild;

--- a/TFHppleElement.m
+++ b/TFHppleElement.m
@@ -157,6 +157,30 @@ static NSString * const TFHppleTextNodeName            = @"text";
     return nil;
 }
 
+- (NSArray*) childrenWithClassName:(NSString*)className
+{
+    NSMutableArray* matches = [NSMutableArray array];
+    
+    for (TFHppleElement* child in self.children)
+    {
+        if ([[child objectForKey:@"class"] isEqualToString:className])
+            [matches addObject:child];
+    }
+    
+    return matches;
+}
+
+- (TFHppleElement *) firstChildWithClassName:(NSString*)className
+{
+    for (TFHppleElement* child in self.children)
+    {
+        if ([[child objectForKey:@"class"] isEqualToString:className])
+            return child;
+    }
+    
+    return nil;
+}
+
 - (TFHppleElement *) firstTextChild;
 {
     for (TFHppleElement* child in self.children)


### PR DESCRIPTION
I added the following methods to `TFHppleElement` to make it easier to find children by their className (class).

```
- (NSArray *) childrenWithClassName:(NSString *)className;
- (TFHppleElement *) firstChildWithClassName:(NSString*)className;
```
