### PR TITLE
Added support for data encoding

### DIFF
--- a/TFHpple.h
+++ b/TFHpple.h
@@ -35,20 +35,28 @@
 @interface TFHpple : NSObject {
 @private
   NSData * data;
+  NSString * encoding;
   BOOL isXML;
 }
 
+- (id) initWithData:(NSData *)theData encoding:(NSString *)encoding isXML:(BOOL)isDataXML;
 - (id) initWithData:(NSData *)theData isXML:(BOOL)isDataXML;
+- (id) initWithXMLData:(NSData *)theData encoding:(NSString *)encoding;
 - (id) initWithXMLData:(NSData *)theData;
+- (id) initWithHTMLData:(NSData *)theData encoding:(NSString *)encoding;
 - (id) initWithHTMLData:(NSData *)theData;
 
++ (TFHpple *) hppleWithData:(NSData *)theData encoding:(NSString *)encoding isXML:(BOOL)isDataXML;
 + (TFHpple *) hppleWithData:(NSData *)theData isXML:(BOOL)isDataXML;
++ (TFHpple *) hppleWithXMLData:(NSData *)theData encoding:(NSString *)encoding;
 + (TFHpple *) hppleWithXMLData:(NSData *)theData;
++ (TFHpple *) hppleWithHTMLData:(NSData *)theData encoding:(NSString *)encoding;
 + (TFHpple *) hppleWithHTMLData:(NSData *)theData;
 
 - (NSArray *) searchWithXPathQuery:(NSString *)xPathOrCSS;
 - (TFHppleElement *) peekAtSearchWithXPathQuery:(NSString *)xPathOrCSS;
 
 @property (nonatomic, strong, readonly) NSData * data;
+@property (nonatomic, strong, readonly) NSString * encoding;
 
 @end

--- a/TFHpple.m
+++ b/TFHpple.m
@@ -35,38 +35,66 @@
 @synthesize data;
 
 
-- (id) initWithData:(NSData *)theData isXML:(BOOL)isDataXML
+- (id) initWithData:(NSData *)theData encoding:(NSString *)theEncoding isXML:(BOOL)isDataXML
 {
   if (!(self = [super init])) {
     return nil;
   }
 
   data = theData;
+  encoding = theEncoding;
   isXML = isDataXML;
 
   return self;
 }
 
+- (id) initWithData:(NSData *)theData isXML:(BOOL)isDataXML
+{
+    return [self initWithData:theData encoding:nil isXML:isDataXML];
+}
+
+- (id) initWithXMLData:(NSData *)theData encoding:(NSString *)theEncoding
+{
+  return [self initWithData:theData encoding:theEncoding isXML:YES];
+}
+
 - (id) initWithXMLData:(NSData *)theData
 {
-  return [self initWithData:theData isXML:YES];
+  return [self initWithData:theData encoding:nil isXML:YES];
+}
+
+- (id) initWithHTMLData:(NSData *)theData encoding:(NSString *)theEncoding
+{
+    return [self initWithData:theData encoding:theEncoding isXML:NO];
 }
 
 - (id) initWithHTMLData:(NSData *)theData
 {
-  return [self initWithData:theData isXML:NO];
+  return [self initWithData:theData encoding:nil isXML:NO];
+}
+
++ (TFHpple *) hppleWithData:(NSData *)theData encoding:(NSString *)theEncoding isXML:(BOOL)isDataXML {
+  return [[[self class] alloc] initWithData:theData encoding:theEncoding isXML:isDataXML];
 }
 
 + (TFHpple *) hppleWithData:(NSData *)theData isXML:(BOOL)isDataXML {
-  return [[[self class] alloc] initWithData:theData isXML:isDataXML];
+  return [[self class] hppleWithData:theData encoding:nil isXML:isDataXML];
+}
+
++ (TFHpple *) hppleWithHTMLData:(NSData *)theData encoding:(NSString *)theEncoding {
+  return [[self class] hppleWithData:theData encoding:theEncoding isXML:NO];
 }
 
 + (TFHpple *) hppleWithHTMLData:(NSData *)theData {
-  return [[self class] hppleWithData:theData isXML:NO];
+  return [[self class] hppleWithData:theData encoding:nil isXML:NO];
+}
+
++ (TFHpple *) hppleWithXMLData:(NSData *)theData encoding:(NSString *)theEncoding {
+  return [[self class] hppleWithData:theData encoding:theEncoding isXML:YES];
 }
 
 + (TFHpple *) hppleWithXMLData:(NSData *)theData {
-  return [[self class] hppleWithData:theData isXML:YES];
+  return [[self class] hppleWithData:theData encoding:nil isXML:YES];
 }
 
 #pragma mark -
@@ -76,9 +104,9 @@
 {
   NSArray * detailNodes = nil;
   if (isXML) {
-    detailNodes = PerformXMLXPathQuery(data, xPathOrCSS);
+    detailNodes = PerformXMLXPathQueryWithEncoding(data, xPathOrCSS, encoding);
   } else {
-    detailNodes = PerformHTMLXPathQuery(data, xPathOrCSS);
+    detailNodes = PerformHTMLXPathQueryWithEncoding(data, xPathOrCSS, encoding);
   }
 
   NSMutableArray * hppleElements = [NSMutableArray array];

--- a/XPathQuery.h
+++ b/XPathQuery.h
@@ -7,4 +7,6 @@
 //
 
 NSArray *PerformHTMLXPathQuery(NSData *document, NSString *query);
+NSArray *PerformHTMLXPathQueryWithEncoding(NSData *document, NSString *query,NSString *encoding);
 NSArray *PerformXMLXPathQuery(NSData *document, NSString *query);
+NSArray *PerformXMLXPathQueryWithEncoding(NSData *document, NSString *query,NSString *encoding);

--- a/XPathQuery.m
+++ b/XPathQuery.m
@@ -168,38 +168,52 @@ NSArray *PerformXPathQuery(xmlDocPtr doc, NSString *query)
 
 NSArray *PerformHTMLXPathQuery(NSData *document, NSString *query)
 {
-  xmlDocPtr doc;
+    return PerformHTMLXPathQueryWithEncoding(document, query, nil);
+}
 
-  /* Load XML document */
-  doc = htmlReadMemory([document bytes], (int)[document length], "", NULL, HTML_PARSE_NOWARNING | HTML_PARSE_NOERROR);
+NSArray *PerformHTMLXPathQueryWithEncoding(NSData *document, NSString *query,NSString *encoding)
+{
+    xmlDocPtr doc;
 
-  if (doc == NULL)
+    /* Load XML document */
+    const char *encoded = encoding ? [encoding cStringUsingEncoding:NSUTF8StringEncoding] : NULL;
+
+    doc = htmlReadMemory([document bytes], (int)[document length], "", encoded, HTML_PARSE_NOWARNING | HTML_PARSE_NOERROR);
+    
+    if (doc == NULL)
     {
-      NSLog(@"Unable to parse.");
-      return nil;
+        NSLog(@"Unable to parse.");
+        return nil;
     }
-
-  NSArray *result = PerformXPathQuery(doc, query);
-  xmlFreeDoc(doc);
-
-  return result;
+    
+    NSArray *result = PerformXPathQuery(doc, query);
+    xmlFreeDoc(doc);
+    
+    return result;
 }
 
 NSArray *PerformXMLXPathQuery(NSData *document, NSString *query)
 {
-  xmlDocPtr doc;
+    return PerformXMLXPathQueryWithEncoding(document, query, nil);
+}
 
-  /* Load XML document */
-  doc = xmlReadMemory([document bytes], (int)[document length], "", NULL, XML_PARSE_RECOVER);
+NSArray *PerformXMLXPathQueryWithEncoding(NSData *document, NSString *query,NSString *encoding)
+{
+    xmlDocPtr doc;
+    
+    /* Load XML document */
+    const char *encoded = encoding ? [encoding cStringUsingEncoding:NSUTF8StringEncoding] : NULL;
 
-  if (doc == NULL)
+    doc = xmlReadMemory([document bytes], (int)[document length], "", encoded, XML_PARSE_RECOVER);
+    
+    if (doc == NULL)
     {
-      NSLog(@"Unable to parse.");
-      return nil;
+        NSLog(@"Unable to parse.");
+        return nil;
     }
-
-  NSArray *result = PerformXPathQuery(doc, query);
-  xmlFreeDoc(doc);
-
-  return result;
+    
+    NSArray *result = PerformXPathQuery(doc, query);
+    xmlFreeDoc(doc);
+    
+    return result;
 }


### PR DESCRIPTION
In response to issues #4 and #9. Added private NSString variable for
encoding, the corresponding readonly property and miscellaneous
initializers. Added PerformHTMLXPathQueryWithEncoding and
PerformXMLXPathQueryWithEncoding to maintain the current interface /
backwards compatibility.
