### PR TITLE
Added safeguards

### DIFF
--- a/XPathQuery.m
+++ b/XPathQuery.m
@@ -40,7 +40,10 @@ NSDictionary *DictionaryForNode(xmlNodePtr currentNode, NSMutableDictionary *par
                 [parentResult setObject:[currentNodeContent stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] forKey:@"nodeContent"];
                 return nil;
             }
-            [resultForNode setObject:currentNodeContent forKey:@"nodeContent"];
+            if (currentNodeContent != nil)
+            {
+                [resultForNode setObject:currentNodeContent forKey:@"nodeContent"];
+            }
 //            NSLog(@"content: %@",currentNodeContent);
             return resultForNode;
 
@@ -112,8 +115,10 @@ NSDictionary *DictionaryForNode(xmlNodePtr currentNode, NSMutableDictionary *par
   xmlNodeDump(buffer, currentNode->doc, currentNode, 0, 0);
 
   NSString *rawContent = [NSString stringWithCString:(const char *)buffer->content encoding:NSUTF8StringEncoding];
-  [resultForNode setObject:rawContent forKey:@"raw"];
-
+  if (rawContent != nil)
+  {
+      [resultForNode setObject:rawContent forKey:@"raw"];
+  }
     xmlBufferFree(buffer);
     
   return resultForNode;


### PR DESCRIPTION
- Only add the “nodeContent” key if “currentNodeContent” is not nil.
- Only add the “raw” key if “rawContent” is not nil.
