### PR TITLE
Quotes around SDKROOT path to allow for spaces

### DIFF
--- a/Hpple.podspec
+++ b/Hpple.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/topfunky/hpple.git", :tag => s.version.to_s }
   s.source_files  = '{TFHpple,TFHppleElement,XPathQuery}.{h,m}'
   s.ios.libraries = 'xml2'
-  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }
   s.requires_arc = true
 end


### PR DESCRIPTION
In our Xcode 5 project, including hpple by cocoapods doesn't work unless I manually add these spaces to the header search path.  This should correct that.
