### PR TITLE
Add module name

### DIFF
--- a/Hpple.podspec
+++ b/Hpple.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.ios.libraries = 'xml2'
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
   s.requires_arc = true
-  s.module_name = "hpple"
+  s.module_name = "Hpple"
 end

--- a/Hpple.podspec
+++ b/Hpple.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.ios.libraries = 'xml2'
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
   s.requires_arc = true
+  s.module_name = "hpple"
 end


### PR DESCRIPTION
This PR will make hpple work with cocoapods when declaring the optional _use_frameworks!_ in the Podfile for swift projects. The hpple module will then be accessible through _import Hpple_ instead of an import directive in a _bridging header_. 

This helped me as some other pods required _use_frameworks!_ and doesn't affect static library users as far as I can tell.