### PR TITLE
Added osx deployment target to podspec

### DIFF
--- a/Hpple.podspec
+++ b/Hpple.podspec
@@ -5,10 +5,11 @@ Pod::Spec.new do |s|
   s.homepage     = "http://topfunky.com"
   s.license      = 'MIT'
   s.author       = "topfunky"
-  s.platform     = :ios, '7.0'
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.9'
   s.source       = { :git => "https://github.com/topfunky/hpple.git", :tag => s.version.to_s }
   s.source_files  = 'Pod/Classes', 'Pod/Classes/**/*.{h,m}'
-  s.ios.libraries = 'xml2'
+  s.library = 'xml2'
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
   s.requires_arc = true
   s.module_name = "Hpple"


### PR DESCRIPTION
Not sure if 10.9 is the right deployment target (could be a lot less I guess, but I have no clue how to try and get that information), but hpple works perfectly fine with OS X. So there's no need to be iOS exclusive.
