### PR TITLE
Fixes Memory Leak on DictionaryForNode(...) function

### DIFF
--- a/Pod/Classes/XPathQuery.m
+++ b/Pod/Classes/XPathQuery.m
@@ -34,11 +34,13 @@ NSDictionary *DictionaryForNode(xmlNodePtr currentNode, NSMutableDictionary *par
             if (parentContent) {
                 NSCharacterSet *charactersToTrim = [NSCharacterSet whitespaceAndNewlineCharacterSet];
                 parentResult[@"nodeContent"] = [currentNodeContent stringByTrimmingCharactersInSet:charactersToTrim];
+                xmlFree(nodeContent);
                 return nil;
             }
             if (currentNodeContent != nil) {
                 resultForNode[@"nodeContent"] = currentNodeContent;
             }
+            xmlFree(nodeContent);
             return resultForNode;
         } else {
             resultForNode[@"nodeContent"] = currentNodeContent;


### PR DESCRIPTION
Fixes #69, Fixes #67: Memory leaks due to a couple of early returns without freeing create nodeContent objects.
