### PR TITLE
Added license to XPathQuery files

### DIFF
--- a/Pod/Classes/XPathQuery.h
+++ b/Pod/Classes/XPathQuery.h
@@ -3,8 +3,19 @@
 //  FuelFinder
 //
 //  Created by Matt Gallagher on 4/08/08.
-//  Copyright 2008 __MyCompanyName__. All rights reserved.
+//  Copyright © 2008-2018 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved.
 //
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee
+//  is hereby granted, provided that the above copyright notice and this permission notice appear in
+//  all copies.
+//
+//  THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+//  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+//  AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+//  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+//  FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH
+//  THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #import <Foundation/Foundation.h>
 

--- a/Pod/Classes/XPathQuery.m
+++ b/Pod/Classes/XPathQuery.m
@@ -3,8 +3,19 @@
 //  FuelFinder
 //
 //  Created by Matt Gallagher on 4/08/08.
-//  Copyright 2008 __MyCompanyName__. All rights reserved.
+//  Copyright © 2008-2018 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved.
 //
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee
+//  is hereby granted, provided that the above copyright notice and this permission notice appear in
+//  all copies.
+//
+//  THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+//  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+//  AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+//  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+//  FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH
+//  THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #import "XPathQuery.h"
 


### PR DESCRIPTION
Related to https://github.com/topfunky/hpple/issues/87

I was in contact with Matt and here is his response:
>"No license info was removed. When I originally posted that in 2008, I had no license on my website. Even the code header is a mess of unreplaced text macros and the internal name of one of my projects. With a mess like that, I think it's fair to say: anything goes 🤷‍♂️"
https://twitter.com/cocoawithlove/status/976800314413129728

So it might not be necessary.

/ Harry